### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  unrs-resolver: true


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能への対応を行います。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。これにより、`pnpm install` 実行時に以下のエラーが発生します:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.7
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

### 修正

`pnpm-workspace.yaml` に `allowBuilds` を追加し、必要なビルドスクリプトを明示的に許可しました。

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)