### PR TITLE
chore: エージェント向けドキュメントを整理し CLAUDE.md と copilot-instructions.md に統一

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,48 @@
+# Copilot code review instructions
+
+Guidance for reviewing pull requests in this repository.
+
+## Project
+
+`fixdevcontainer` is a zero-dependency Node.js CLI that reorders the top-level keys
+of a `devcontainer.json` into a fixed category order. The whole implementation lives
+in `fixdevcontainer.js`; tests are in `fixdevcontainer.test.js` (Jest).
+
+## Tech stack
+
+- Node.js (version pinned in `.node-version`), CommonJS modules.
+- pnpm for package management; Jest for tests.
+- No lint/format tool is configured, so enforce style by consistency with the
+  existing code, not by tooling.
+
+## Review focus
+
+- **Sort order (`predefinedOrder`)**: verify new keys are placed in the correct
+  category and that category comments stay accurate. Flag duplicated keys within
+  the array (`userEnvProbe` currently appears twice — call out any new duplicates).
+- **Unknown-key handling**: keys absent from `predefinedOrder` must still be
+  preserved and appended alphabetically. Flag changes that could silently drop keys.
+- **Error handling**: `loadJson`/`formatter` must log and return early on missing
+  file, read failure, and JSON parse failure rather than throwing. Flag new code
+  paths that throw uncaught or write partial output.
+- **Console output**: messages use exact ANSI escape codes (red `[31m` errors,
+  yellow `[33m` warnings, green `[32m` success). Flag output changes that are not
+  matched by a corresponding test update, since tests assert exact strings.
+- **Tests**: any change to sorting behavior or messages should come with updated or
+  new Jest cases. Tests mock `node:fs` and `console`, so flag tests that perform
+  real filesystem I/O.
+
+## Style
+
+- CommonJS `require`/`exports`; import builtins with the `node:` prefix.
+- 2-space indentation, double quotes, semicolons.
+
+## Do not flag
+
+- Absence of a lint/format config or a build step — this is intentional.
+- Raw ANSI escape sequences in strings — these are the intended output format.
+- The lack of runtime dependencies — the tool is deliberately dependency-free.
+
+## Language
+
+Write review comments in Japanese, matching the repository's commit history.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,11 @@ are preserved and appended alphabetically at the end with a warning.
 ## Development commands
 
 - `pnpm test`: run the Jest test suite (`fixdevcontainer.test.js`). This is the
-  only script and is what CI runs. There is no build step and no lint/format tool
-  configured.
+  only npm script defined; there is no build step and no lint/format tool
+  configured. CI (the reusable `book000/templates` Node CI workflow) runs this
+  test plus `npx depcheck`, which is why `.depcheckrc.json` exists (it ignores
+  `jest`, which is only referenced via config). Keep dependencies clean so
+  `depcheck` stays green.
 - `npx fixdevcontainer [file]`: run the tool. Defaults to
   `.devcontainer/devcontainer.json` when no path is given.
 
@@ -33,8 +36,10 @@ Use pnpm (see `packageManager` in `package.json`). Node version is pinned in
     `process.argv[2]`.
 - `fixdevcontainer.test.js`: Jest tests that mock `node:fs` and the `console`
   methods.
-- `.github/workflows/`: CI (`nodejs-ci-pnpm.yml`) and npm publish (`release.yml`)
-  reuse `book000/templates` workflows.
+- `.github/workflows/`: CI (`nodejs-ci-pnpm.yml`) and reviewer assignment
+  (`add-reviewer.yml`) reuse `book000/templates` workflows. npm publish
+  (`release.yml`) is a standalone workflow that defines its steps inline
+  (tag bump via `mathieudutour/github-tag-action`, then `pnpm publish`).
 
 ## Coding conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+## Overview
+
+`fixdevcontainer` is a zero-dependency CLI that sorts the top-level keys of a
+`devcontainer.json` file into a fixed, human-friendly category order (basic info,
+container image, operational settings, ports, features, lifecycle commands, etc.).
+It is published to npm and typically run with `npx fixdevcontainer`. Unknown keys
+are preserved and appended alphabetically at the end with a warning.
+
+## Development commands
+
+- `pnpm test`: run the Jest test suite (`fixdevcontainer.test.js`). This is the
+  only script and is what CI runs. There is no build step and no lint/format tool
+  configured.
+- `npx fixdevcontainer [file]`: run the tool. Defaults to
+  `.devcontainer/devcontainer.json` when no path is given.
+
+Use pnpm (see `packageManager` in `package.json`). Node version is pinned in
+`.node-version`.
+
+## Architecture / key files
+
+- `fixdevcontainer.js`: the entire implementation. CommonJS, `"use strict"`, with
+  a `#!/usr/bin/env node` shebang; it is the package `bin` and `main`.
+  - `predefinedOrder`: the ordered array of known keys, grouped by category with
+    comments. This array is the heart of the tool.
+  - `loadJson(filename)`: reads and parses the file, returning `null` on any error
+    (missing file, read error, parse error).
+  - `formatter(filename)`: reorders keys per `predefinedOrder`, appends unknown
+    keys alphabetically, and writes the result back with `JSON.stringify(obj, null, 2)`.
+    Exported via `exports.formatter` for tests; also invoked at module load using
+    `process.argv[2]`.
+- `fixdevcontainer.test.js`: Jest tests that mock `node:fs` and the `console`
+  methods.
+- `.github/workflows/`: CI (`nodejs-ci-pnpm.yml`) and npm publish (`release.yml`)
+  reuse `book000/templates` workflows.
+
+## Coding conventions
+
+- CommonJS (`require`/`exports`), not ESM. Import Node builtins with the `node:`
+  prefix (e.g. `require("node:fs")`).
+- 2-space indentation, double-quoted strings, semicolons — match the existing file.
+- User-facing output uses raw ANSI escape codes: red (`[31m`) for errors via
+  `console.error`, yellow (`[33m`) for warnings via `console.warn`, green
+  (`[32m`) for success via `console.log`. The tests assert these exact
+  strings, so keep the escape sequences and message wording in sync with the tests.
+- On errors, log a message and return early (return `null`/`undefined`); do not
+  throw out of `formatter`/`loadJson`.
+
+## Adding or changing sorted keys
+
+When adding support for a new `devcontainer.json` property, insert it into
+`predefinedOrder` in the appropriate category (keep the section comments accurate).
+Note that `formatter` copies only keys present in `predefinedOrder` into the sorted
+object; any key not listed there is treated as "undefined" and appended
+alphabetically. Update `fixdevcontainer.test.js` to cover the new ordering.
+
+## Testing approach
+
+Tests mock `node:fs` (`existsSync`/`readFileSync`/`writeFileSync`) and stub
+`console.log`/`warn`/`error`, then assert the arguments passed to `writeFileSync`
+and the console output. There is no real filesystem I/O in tests. Add a case for
+every new behavior rather than relying on manual runs.
+
+## Commit / release rules
+
+- Commits follow Conventional Commits; descriptions are written in Japanese by
+  default (matching the existing history).
+- `release.yml` parses commit prefixes to bump the version and publish to npm:
+  `feat` → minor, `fix`/`chore`/`docs`/`refactor`/etc. → patch, `release` → major.
+  Choose the prefix deliberately since it drives the released version.


### PR DESCRIPTION
## 概要

AI エージェント向けのプロジェクトガイドを新規に整備しました。既存の `AGENTS.md` / `GEMINI.md` は元々存在しなかったため、削除ではなく新規作成のみです。

## 変更内容

### 新規追加

- **`CLAUDE.md`**: プロジェクト概要、開発コマンド、アーキテクチャ(`fixdevcontainer.js` の `predefinedOrder` / `loadJson` / `formatter`)、コーディング規約、ソートキー追加手順、テスト方針、コミット/リリース規則を記載。
- **`.github/copilot-instructions.md`**: Copilot コードレビュー向けの観点(ソート順、未知キーの保全、エラーハンドリング、ANSI 出力とテストの同期、fs/console のモック)と、フラグすべきでない事項(lint/format 設定やビルドステップの不在、生 ANSI エスケープ、依存ゼロ設計)を記載。

## レビューで修正した点

執筆内容を実リポジトリと突き合わせて独立検証し、以下の実態乖離を修正しました(コミット `95df2f5`):

- CI が `pnpm test` に加えて `npx depcheck` を実行する点(`.depcheckrc.json` の存在理由)を追記。reusable ワークフロー `book000/templates` の実内容を確認済み。
- `release.yml` は `book000/templates` の reusable ワークフローではなく、全ステップをインライン定義した独立ワークフローである点を訂正(reusable を使うのは `nodejs-ci-pnpm.yml` と `add-reviewer.yml`)。

## 検証

- `pnpm test` で 6 件全て pass(挙動変更なし)。
- CLAUDE.md / copilot-instructions.md の記載コマンド・ファイルパス・設定値・ANSI コード・ワークフロー構成を実ファイルと 1 つずつ照合済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)